### PR TITLE
Include host pin header when retrieving log list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2486,15 +2486,20 @@ function onBidCustom(){
 	  }
 	}
 
-	async function loadLogList() {
+        async function loadLogList() {
   try {
-    const res = await fetch('/logs/list');
+    const res = await fetch('/logs/list', {
+      headers: { 'x-host-pin': hostPin || '' }
+    });
     const j = await res.json();
     const sel = document.getElementById('logFileSelect');
     const btn = document.getElementById('logDownloadBtn');
     if (!sel || !btn) return;
 
-    if (!j.success) throw new Error(j.error || 'Errore elenco log');
+    if (!j.success) {
+      showToast(j.error || 'Errore elenco log', 'error');
+      return;
+    }
 
     sel.innerHTML = j.files.map(f => `<option value="${f}">${f}</option>`).join('');
     if (j.files.length) {


### PR DESCRIPTION
## Summary
- include `x-host-pin` header when fetching log list
- display toast on log-list API error responses

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beedfb76ec8332a0669930f766d3ab